### PR TITLE
Add parameters to ecl connection update

### DIFF
--- a/fic/resource_eri_router_to_ecl_connection_v1.go
+++ b/fic/resource_eri_router_to_ecl_connection_v1.go
@@ -248,6 +248,16 @@ func resourceEriRouterToECLConnectionV1Update(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Error creating FIC ERI client: %s", err)
 	}
 
+	var updateOptsList = []connections.UpdateOpts{}
+
+	if d.HasChange("name") {
+		updateOptsList = append(updateOptsList,
+			connections.UpdateOpts{
+				Name: d.Get("name").(string),
+			},
+		)
+	}
+
 	if d.HasChange("source_route_filter_in") || d.HasChange("source_route_filter_out") {
 		routeFilter := connections.RouteFilter{
 			In:  d.Get("source_route_filter_in").(string),
@@ -256,9 +266,22 @@ func resourceEriRouterToECLConnectionV1Update(d *schema.ResourceData, meta inter
 		source := connections.SourceForUpdate{
 			RouteFilter: routeFilter,
 		}
-		updateOpts := connections.UpdateOpts{
-			Source: source,
-		}
+		updateOptsList = append(updateOptsList,
+			connections.UpdateOpts{
+				Source: &source,
+			},
+		)
+	}
+
+	if d.HasChange("bandwidth") {
+		updateOptsList = append(updateOptsList,
+			connections.UpdateOpts{
+				Bandwidth: d.Get("bandwidth").(string),
+			},
+		)
+	}
+
+	for _, updateOpts := range updateOptsList {
 		_, err := connections.Update(client, d.Id(), updateOpts).Extract()
 		if err != nil {
 			return fmt.Errorf("Error activating FIC ERI connection: %s", err)

--- a/fic/resource_eri_router_to_ecl_connection_v1_test.go
+++ b/fic/resource_eri_router_to_ecl_connection_v1_test.go
@@ -32,6 +32,28 @@ func TestAccEriRouterToECLConnectionV1Basic(t *testing.T) {
 				Config: testAccConfigEriRouterToECLConnectionV1Update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEriRouterToECLConnectionV1Exists("fic_eri_router_to_ecl_connection_v1.connection_1", &c),
+					resource.TestCheckResourceAttr(
+						"fic_eri_router_to_ecl_connection_v1.connection_1", "name", "terraform_connection_1"),
+					resource.TestCheckResourceAttr(
+						"fic_eri_router_to_ecl_connection_v1.connection_1", "source_route_filter_in", "fullRoute"),
+					resource.TestCheckResourceAttr(
+						"fic_eri_router_to_ecl_connection_v1.connection_1", "source_route_filter_out", "fullRouteWithDefaultRoute"),
+					resource.TestCheckResourceAttr(
+						"fic_eri_router_to_ecl_connection_v1.connection_1", "bandwidth", "10M"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccConfigEriRouterToECLConnectionV1Update2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEriRouterToECLConnectionV1Exists("fic_eri_router_to_ecl_connection_v1.connection_1", &c),
+					resource.TestCheckResourceAttr(
+						"fic_eri_router_to_ecl_connection_v1.connection_1", "name", "terraform_connection_2"),
+					resource.TestCheckResourceAttr(
+						"fic_eri_router_to_ecl_connection_v1.connection_1", "source_route_filter_in", "noRoute"),
+					resource.TestCheckResourceAttr(
+						"fic_eri_router_to_ecl_connection_v1.connection_1", "source_route_filter_out", "noRoute"),
+					resource.TestCheckResourceAttr(
+						"fic_eri_router_to_ecl_connection_v1.connection_1", "bandwidth", "20M"),
 				),
 			},
 		},
@@ -107,7 +129,7 @@ resource "fic_eri_router_to_ecl_connection_v1" "connection_1" {
 	source_route_filter_in = "noRoute"
 	source_route_filter_out = "noRoute"
 
-	destination_interconnect = "ECL-OSA-GU-Z1-01"
+	destination_interconnect = "ECL-TYO-GU-Z1-01"
 	destination_qos_type = "guarantee"
 	destination_ecl_tenant_id = "%s"
 	destination_ecl_api_key = "%s"
@@ -141,13 +163,47 @@ resource "fic_eri_router_to_ecl_connection_v1" "connection_1" {
 	source_route_filter_in = "fullRoute"
 	source_route_filter_out = "fullRouteWithDefaultRoute"
 
-	destination_interconnect = "ECL-OSA-GU-Z1-01"
+	destination_interconnect = "ECL-TYO-GU-Z1-01"
 	destination_qos_type = "guarantee"
 	destination_ecl_tenant_id = "%s"
 	destination_ecl_api_key = "%s"
 	destination_ecl_api_secret_key = "%s"
 
 	bandwidth = "10M"
+
+	primary_connected_network_address = "192.168.0.0/30"
+	secondary_connected_network_address = "192.168.1.0/30"
+}
+`,
+	OS_AREA_NAME,
+	OS_ECL_TENANT_ID,
+	OS_ECL_API_KEY,
+	OS_ECL_API_SECRET_KEY,
+)
+
+var testAccConfigEriRouterToECLConnectionV1Update2 = fmt.Sprintf(`
+resource "fic_eri_router_v1" "router_1" {
+	name = "terraform_router_1"
+	area = "%s"
+	user_ip_address = "10.0.0.0/27"
+	redundant = false
+}
+
+resource "fic_eri_router_to_ecl_connection_v1" "connection_1" {
+	name = "terraform_connection_2"
+	source_router_id = "${fic_eri_router_v1.router_1.id}"
+
+	source_group_name = "group_1"
+	source_route_filter_in = "noRoute"
+	source_route_filter_out = "noRoute"
+
+	destination_interconnect = "ECL-TYO-GU-Z1-01"
+	destination_qos_type = "guarantee"
+	destination_ecl_tenant_id = "%s"
+	destination_ecl_api_key = "%s"
+	destination_ecl_api_secret_key = "%s"
+
+	bandwidth = "20M"
 
 	primary_connected_network_address = "192.168.0.0/30"
 	secondary_connected_network_address = "192.168.1.0/30"

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/mapstructure v1.3.2 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/nttcom/go-fic v1.0.4
+	github.com/nttcom/go-fic v1.0.5
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -423,8 +423,6 @@ github.com/nbutton23/zxcvbn-go v0.0.0-20171102151520-eafdab6b0663 h1:Ri1EhipkbhW
 github.com/nbutton23/zxcvbn-go v0.0.0-20171102151520-eafdab6b0663/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nttcom/go-fic v1.0.4 h1:Widi3BlO18kCTnhfh0VfW7r5JMWcfC3zEMtcb//1KVA=
-github.com/nttcom/go-fic v1.0.4/go.mod h1:I6SsvzBk6X8jffKsxxzLOSmOdtCvak7cRGllgghUH/c=
 github.com/nttcom/go-fic v1.0.5 h1:Y/ReKe5Iww6TeAOWRYamvQcZKg7kOdUaaHBsbgch+vE=
 github.com/nttcom/go-fic v1.0.5/go.mod h1:I6SsvzBk6X8jffKsxxzLOSmOdtCvak7cRGllgghUH/c=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/go.sum
+++ b/go.sum
@@ -425,6 +425,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nttcom/go-fic v1.0.4 h1:Widi3BlO18kCTnhfh0VfW7r5JMWcfC3zEMtcb//1KVA=
 github.com/nttcom/go-fic v1.0.4/go.mod h1:I6SsvzBk6X8jffKsxxzLOSmOdtCvak7cRGllgghUH/c=
+github.com/nttcom/go-fic v1.0.5 h1:Y/ReKe5Iww6TeAOWRYamvQcZKg7kOdUaaHBsbgch+vE=
+github.com/nttcom/go-fic v1.0.5/go.mod h1:I6SsvzBk6X8jffKsxxzLOSmOdtCvak7cRGllgghUH/c=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=


### PR DESCRIPTION
router-to-ecl-connections の `name`と `bandwidth`が更新できるようになったので，これの対応になります．
- ただし，[FICドキュメント](https://fic.ntt.com/documents/api-references/connection-ecl/rsts/Router%20to%20ECL.html#update-router-to-ecl2-0-connection) を見ると `name`， `bandwidth`，`source`を同一リクエストで変更することはできないため，terraform側で最大3回にリクエストを分けて変更を実施するようにしています
  - sdkである go-fic 側でも単独でなげる実装およびテストを実施しています: [PR](https://github.com/nttcom/go-fic/pull/11)