### PR TITLE
IF-6001 Update FIC-Connection GCP interconnect validation

### DIFF
--- a/fic/resource_eri_router_paired_to_gcp_connection_v1.go
+++ b/fic/resource_eri_router_paired_to_gcp_connection_v1.go
@@ -18,7 +18,7 @@ import (
 
 func resourcePairedRouterToGCPConnection() *schema.Resource {
 	validInterconnects := []string{
-		"Equinix-TY2-2", "@Tokyo-CC2-2", "Equinix-TY2-3", "@Tokyo-CC2-3", "Equinix-OS1-1", "NTT-Dojima2-1",
+		"Equinix-TY2-3", "Equinix-TY2-4", "@Tokyo-CC2-3", "@Tokyo-CC2-4", "Equinix-OS1-1", "Equinix-OS1-3", "NTT-Dojima2-1", "NTT-Dojima2-3",
 	}
 	interconnectSchema := &schema.Resource{
 		Schema: map[string]*schema.Schema{

--- a/fic/resource_eri_router_paired_to_gcp_connection_v1_test.go
+++ b/fic/resource_eri_router_paired_to_gcp_connection_v1_test.go
@@ -39,9 +39,9 @@ func TestAccPairedRouterToGCPConnection_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "source.0.route_filter.0.out", "privateRoute"),
 					resource.TestCheckResourceAttr(resourceName, "source.0.primary_med_out", "10"),
 					resource.TestCheckResourceAttr(resourceName, "source.0.secondary_med_out", "20"),
-					resource.TestCheckResourceAttr(resourceName, "destination.0.primary.0.interconnect", "Equinix-TY2-2"),
+					resource.TestCheckResourceAttr(resourceName, "destination.0.primary.0.interconnect", "Equinix-TY2-4"),
 					resource.TestCheckResourceAttrSet(resourceName, "destination.0.primary.0.pairing_key"),
-					resource.TestCheckResourceAttr(resourceName, "destination.0.secondary.0.interconnect", "@Tokyo-CC2-2"),
+					resource.TestCheckResourceAttr(resourceName, "destination.0.secondary.0.interconnect", "@Tokyo-CC2-4"),
 					resource.TestCheckResourceAttrSet(resourceName, "destination.0.secondary.0.pairing_key"),
 					resource.TestCheckResourceAttr(resourceName, "destination.0.qos_type", "guarantee"),
 					resource.TestCheckResourceAttr(resourceName, "redundant", "true"),
@@ -65,9 +65,9 @@ func TestAccPairedRouterToGCPConnection_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "source.0.route_filter.0.out", "defaultRoute"),
 					resource.TestCheckResourceAttr(resourceName, "source.0.primary_med_out", "30"),
 					resource.TestCheckResourceAttr(resourceName, "source.0.secondary_med_out", "40"),
-					resource.TestCheckResourceAttr(resourceName, "destination.0.primary.0.interconnect", "Equinix-TY2-2"),
+					resource.TestCheckResourceAttr(resourceName, "destination.0.primary.0.interconnect", "Equinix-TY2-4"),
 					resource.TestCheckResourceAttrSet(resourceName, "destination.0.primary.0.pairing_key"),
-					resource.TestCheckResourceAttr(resourceName, "destination.0.secondary.0.interconnect", "@Tokyo-CC2-2"),
+					resource.TestCheckResourceAttr(resourceName, "destination.0.secondary.0.interconnect", "@Tokyo-CC2-4"),
 					resource.TestCheckResourceAttrSet(resourceName, "destination.0.secondary.0.pairing_key"),
 					resource.TestCheckResourceAttr(resourceName, "destination.0.qos_type", "guarantee"),
 					resource.TestCheckResourceAttr(resourceName, "redundant", "true"),
@@ -198,11 +198,11 @@ resource "fic_eri_router_paired_to_gcp_connection_v1" "test" {
 	}
 	destination {
 		primary {
-			interconnect = "Equinix-TY2-2"
+			interconnect = "Equinix-TY2-4"
 			pairing_key = google_compute_interconnect_attachment.test1.pairing_key
 		}
 		secondary {
-			interconnect = "@Tokyo-CC2-2"
+			interconnect = "@Tokyo-CC2-4"
 			pairing_key = google_compute_interconnect_attachment.test2.pairing_key
 		}
 	}

--- a/website/docs/r/eri_router_paired_to_gcp_connection_v1.html.markdown
+++ b/website/docs/r/eri_router_paired_to_gcp_connection_v1.html.markdown
@@ -66,11 +66,11 @@ resource "fic_eri_router_paired_to_gcp_connection_v1" "connection" {
 	}
 	destination {
 		primary {
-			interconnect = "Equinix-TY2-2"
+			interconnect = "Equinix-TY2-4"
 			pairing_key = google_compute_interconnect_attachment.interconnect1.pairing_key
 		}
 		secondary {
-			interconnect = "@Tokyo-CC2-2"
+			interconnect = "@Tokyo-CC2-4"
 			pairing_key = google_compute_interconnect_attachment.interconnect2.pairing_key
 		}
 	}
@@ -118,7 +118,8 @@ The `destination` block supports:
 The `primary` and `secondary` blocks support:
 
 * `interconnect` - (Required) Connecting point.
-  Either "Equinix-TY2-2", "@Tokyo-CC2-2", "Equinix-TY2-3", "@Tokyo-CC2-3", "Equinix-OS1-1" or "NTT-Dojima2-1".
+  Either "Equinix-TY2-3", "Equinix-TY2-4", "@Tokyo-CC2-3", "@Tokyo-CC2-4", "Equinix-OS1-1", "Equinix-OS1-3",
+  "NTT-Dojima2-1" or "NTT-Dojima2-3".
 
 * `pairing_key` - (Required) Paring key of google hybrid interconnect.
 


### PR DESCRIPTION
resource_eri_router_paired_to_gcp_connection の interconnect に関するバリデーションを修正しています。
新しく追加されている Connecting Point や既に提供停止されている Connecting Point があり、最新のドキュメントの通りにしました。

(詳細情報  [ドキュメント : Smart Data Platform](https://sdpf.ntt.com/services/docs/fic/service-descriptions/connection-gcp/connection-gcp.html#id4) を参照のこと)

website の記載や、Test の記載も古かったため併せて最新化しています。