### PR TITLE
fix fic provider example version 0.5.3->0.5.4

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     fic = {
       source  = "nttcom/fic"
-      version = "0.5.3"
+      version = "0.5.4"
     }
   }
 }


### PR DESCRIPTION
https://registry.terraform.io/providers/nttcom/fic/latest/docs

Example Usage provider version 0.5.3 -> 0.5.4