### PR TITLE
:bug: IF-10137 Fix to return error when update of firewall is failed

### DIFF
--- a/fic/resource_eri_firewall_component.go
+++ b/fic/resource_eri_firewall_component.go
@@ -250,8 +250,7 @@ func resourceEriFirewallComponentV1Activate(d *schema.ResourceData, meta interfa
 	log.Printf("[DEBUG] RoutingGroupSettings  are set as: %#v", routingGroupSettings)
 
 	if len(rules) > 0 || len(customApplications) > 0 || len(applicationSets) > 0 || len(routingGroupSettings) > 0 {
-		err := updateFirewall(d, meta)
-		if err != nil {
+		if err := updateFirewall(d, meta); err != nil {
 			return fmt.Errorf("Error updating firewall component: %s", err)
 		}
 	}

--- a/fic/resource_eri_firewall_component.go
+++ b/fic/resource_eri_firewall_component.go
@@ -294,8 +294,7 @@ func resourceEriFirewallComponentV1Update(d *schema.ResourceData, meta interface
 		d.HasChange("application_sets") || d.HasChange("routing_group_settings") {
 
 		log.Printf("[DEBUG] Firewall is going to update...")
-		err := updateFirewall(d, meta)
-		if err != nil {
+		if err := updateFirewall(d, meta); err != nil {
 			return fmt.Errorf("Error updating firewall component: %s", err)
 		}
 	}
@@ -324,7 +323,7 @@ func updateFirewall(d *schema.ResourceData, meta interface{}) error {
 		}
 		_, err := firewalls.Update(client, routerID, firewallID, updateOpts).Extract()
 		if err != nil {
-			return fmt.Errorf("Error updating FIC ERI nat component: %s", err)
+			return fmt.Errorf("Error updating firewall component: %s", err)
 		}
 
 		log.Printf(

--- a/fic/resource_eri_firewall_component.go
+++ b/fic/resource_eri_firewall_component.go
@@ -250,7 +250,10 @@ func resourceEriFirewallComponentV1Activate(d *schema.ResourceData, meta interfa
 	log.Printf("[DEBUG] RoutingGroupSettings  are set as: %#v", routingGroupSettings)
 
 	if len(rules) > 0 || len(customApplications) > 0 || len(applicationSets) > 0 || len(routingGroupSettings) > 0 {
-		updateFirewall(d, meta)
+		err := updateFirewall(d, meta)
+		if err != nil {
+			return fmt.Errorf("Error updating firewall component: %s", err)
+		}
 	}
 
 	return resourceEriFirewallComponentV1Read(d, meta)
@@ -292,7 +295,10 @@ func resourceEriFirewallComponentV1Update(d *schema.ResourceData, meta interface
 		d.HasChange("application_sets") || d.HasChange("routing_group_settings") {
 
 		log.Printf("[DEBUG] Firewall is going to update...")
-		updateFirewall(d, meta)
+		err := updateFirewall(d, meta)
+		if err != nil {
+			return fmt.Errorf("Error updating firewall component: %s", err)
+		}
 	}
 	return resourceEriFirewallComponentV1Read(d, meta)
 }
@@ -399,7 +405,7 @@ func FirewallComponentV1StateRefreshFunc(client *fic.ServiceClient, id string) r
 }
 
 func getRules(d *schema.ResourceData) []firewalls.Rule {
-	var result []firewalls.Rule
+	result := make([]firewalls.Rule, 0)
 
 	rawRules := d.Get("rules").([]interface{})
 	for _, r := range rawRules {
@@ -451,7 +457,7 @@ func getRules(d *schema.ResourceData) []firewalls.Rule {
 }
 
 func getCustomApplications(d *schema.ResourceData) []firewalls.CustomApplication {
-	var result []firewalls.CustomApplication
+	result := make([]firewalls.CustomApplication, 0)
 	rawCustomApplications := d.Get("custom_applications").([]interface{})
 	for _, r := range rawCustomApplications {
 		name := r.(map[string]interface{})["name"].(string)
@@ -469,7 +475,7 @@ func getCustomApplications(d *schema.ResourceData) []firewalls.CustomApplication
 }
 
 func getApplicationSets(d *schema.ResourceData) []firewalls.ApplicationSet {
-	var result []firewalls.ApplicationSet
+	result := make([]firewalls.ApplicationSet, 0)
 
 	rawApplicationSets := d.Get("application_sets").([]interface{})
 	for _, r := range rawApplicationSets {
@@ -491,7 +497,7 @@ func getApplicationSets(d *schema.ResourceData) []firewalls.ApplicationSet {
 }
 
 func getRoutingGroupSettings(d *schema.ResourceData) []firewalls.RoutingGroupSetting {
-	var result []firewalls.RoutingGroupSetting
+	result := make([]firewalls.RoutingGroupSetting, 0)
 	rawRoutingGroupSettings := d.Get("routing_group_settings").([]interface{})
 	for _, r := range rawRoutingGroupSettings {
 		groupName := r.(map[string]interface{})["group_name"].(string)

--- a/fic/resource_eri_firewall_component_v1_test.go
+++ b/fic/resource_eri_firewall_component_v1_test.go
@@ -134,8 +134,8 @@ func testAccCheckEriFirewallComponentV1Destroy(s *terraform.State) error {
 		id := rs.Primary.ID
 		routerID := strings.Split(id, "/")[0]
 		firewallID := strings.Split(id, "/")[1]
-		_, err := firewalls.Get(client, routerID, firewallID).Extract()
-		if err == nil {
+		v, err := firewalls.Get(client, routerID, firewallID).Extract()
+		if err == nil && v.OperationStatus != "Completed" {
 			return fmt.Errorf("Firewall Component still exists")
 		}
 	}


### PR DESCRIPTION
* fic/resource_eri_firewall_component.go
  - FIC-FWの更新API呼出処理（updateFirewall関数）について戻り値のエラー判定処理を追加
  - rules, customApplications, applicationSets, routingGroupSettingsについて宣言時の値を空リストに修正
* fic/resource_eri_firewall_component_v1_test.go
  - パラメーターOperationStatusの値が "Completed"のときも FIC-FWは削除されたとみなすよう修正