### PR TITLE
:bug: IF-10137 Fix to return error when update of nat is failed

### DIFF
--- a/fic/resource_eri_nat_component.go
+++ b/fic/resource_eri_nat_component.go
@@ -229,7 +229,9 @@ func resourceEriNATComponentV1Activate(d *schema.ResourceData, meta interface{})
 	log.Printf("[DEBUG] Destination NAT Rule is set as: %#v", destinationNATRules)
 
 	if len(sourceNAPTRules) > 0 || len(destinationNATRules) > 0 {
-		updateSourceNAPTORDestinationNAT(d, meta)
+		if err := updateSourceNAPTORDestinationNAT(d, meta); err != nil {
+			return fmt.Errorf("Error updating nat component: %s", err)
+		}
 	}
 
 	return resourceEriNATComponentV1Read(d, meta)
@@ -267,7 +269,9 @@ func resourceEriNATComponentV1Update(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] d.HasChange('destination_nat_rules'): %#v", d.HasChange("source_napt_rules"))
 	if d.HasChange("source_napt_rules") || d.HasChange("destination_nat_rules") {
 		log.Printf("[DEBUG] Either Source NAPT or Destination NAT is going to update...")
-		updateSourceNAPTORDestinationNAT(d, meta)
+		if err := updateSourceNAPTORDestinationNAT(d, meta); err != nil {
+			return fmt.Errorf("Error updating nat component: %s", err)
+		}
 	}
 	return resourceEriNATComponentV1Read(d, meta)
 }

--- a/fic/resource_eri_nat_component_v1_test.go
+++ b/fic/resource_eri_nat_component_v1_test.go
@@ -137,8 +137,8 @@ func testAccCheckEriNATComponentV1Destroy(s *terraform.State) error {
 		id := rs.Primary.ID
 		routerID := strings.Split(id, "/")[0]
 		natID := strings.Split(id, "/")[1]
-		_, err := nats.Get(client, routerID, natID).Extract()
-		if err == nil {
+		v, err := nats.Get(client, routerID, natID).Extract()
+		if err == nil && v.OperationStatus != "Completed" {
 			return fmt.Errorf("NAT Component still exists")
 		}
 	}


### PR DESCRIPTION
* fic/resource_eri_nat_component.go
  - FIC-NATの更新API呼出処理（updateSourceNAPTORDestinationNAT関数）について戻り値のエラー判定処理を追加
* fic/resource_eri_nat_component_v1_test.go
  - パラメーターOperationStatusの値が "Completed"のときも FIC-NATは削除されたとみなすよう修正